### PR TITLE
Generalize server stubbing for integration tests

### DIFF
--- a/cypress/integration/auth.spec.js
+++ b/cypress/integration/auth.spec.js
@@ -19,7 +19,7 @@ describe('Consumer authentication', function(){
 
     it('redirects to home page if identified Consumer browses /login', function () {
       // Given
-      cy.stubServer('Authentication/LogConsumerIn/Consommateur')
+      cy.stubServer('Authentication/Login/Consommateur')
       login(email, password)
 
       // When
@@ -31,7 +31,7 @@ describe('Consumer authentication', function(){
 
     it('pops up an error message if a Consumer logs in with invalid e-mail and password', function() {
       // Given
-      cy.stubServer('Authentication/LogConsumerIn/WrongCredentials')
+      cy.stubServer('Authentication/Login/WrongCredentials')
 
       // When
       cy.visit('/login')
@@ -46,7 +46,7 @@ describe('Consumer authentication', function(){
 
     it('pops up an error message if a registered Consumer logs in with an invalid password', function() {
       // Given
-      cy.stubServer('Authentication/LogConsumerIn/WrongCredentials')
+      cy.stubServer('Authentication/Login/WrongCredentials')
 
       // When
       cy.visit('/login')
@@ -61,7 +61,7 @@ describe('Consumer authentication', function(){
 
     it('opens a session if the Consumer provides the correct credentials', function() {
       // Given
-      cy.stubServer('Authentication/LogConsumerIn/Consommateur')
+      cy.stubServer('Authentication/Login/Consommateur')
 
       // When
       cy.visit('/login')
@@ -83,7 +83,7 @@ describe('Consumer authentication', function(){
 
     it('forgets about the token and redirects to /', function () {
       // Given
-      cy.stubServer('Authentication/LogConsumerIn/Consommateur')
+      cy.stubServer('Authentication/Login/Consommateur')
       login(email, password)
 
       // When

--- a/cypress/integration/auth.spec.js
+++ b/cypress/integration/auth.spec.js
@@ -19,7 +19,10 @@ describe('Consumer authentication', function(){
 
     it('redirects to home page if identified Consumer browses /login', function () {
       // Given
-      cy.stubServer('Authentication/Login/Consommateur')
+      cy.stubServer({
+        'Login': 'Authentication/Login/Consommateur'
+      })
+
       login(email, password)
 
       // When
@@ -31,7 +34,9 @@ describe('Consumer authentication', function(){
 
     it('pops up an error message if a Consumer logs in with invalid e-mail and password', function() {
       // Given
-      cy.stubServer('Authentication/Login/WrongCredentials')
+      cy.stubServer({
+        'Login': 'Authentication/Login/WrongCredentials'
+      })
 
       // When
       cy.visit('/login')
@@ -46,7 +51,9 @@ describe('Consumer authentication', function(){
 
     it('pops up an error message if a registered Consumer logs in with an invalid password', function() {
       // Given
-      cy.stubServer('Authentication/Login/WrongCredentials')
+      cy.stubServer({
+        'Login': 'Authentication/Login/WrongCredentials'
+      })
 
       // When
       cy.visit('/login')
@@ -61,7 +68,10 @@ describe('Consumer authentication', function(){
 
     it('opens a session if the Consumer provides the correct credentials', function() {
       // Given
-      cy.stubServer('Authentication/Login/Consommateur')
+      cy.stubServer({
+        'Login': 'Authentication/Login/Consommateur'
+      })
+
 
       // When
       cy.visit('/login')
@@ -83,7 +93,9 @@ describe('Consumer authentication', function(){
 
     it('forgets about the token and redirects to /', function () {
       // Given
-      cy.stubServer('Authentication/Login/Consommateur')
+      cy.stubServer({
+        'Login': 'Authentication/Login/Consommateur'
+      })
       login(email, password)
 
       // When
@@ -137,7 +149,9 @@ describe('Consumer authentication', function(){
 
     it('registers new Consumer with compliant password', function () {
       // Given
-      cy.stubServer('Authentication/RegisterConsumer/SuccessfulConsumerCreation')
+      cy.stubServer({
+        'SignUp': 'Authentication/RegisterConsumer/SuccessfulConsumerCreation'
+      })
 
       // When
       accessRegistrationInterface()
@@ -163,7 +177,9 @@ describe('Consumer authentication', function(){
         
     it('displays a success message when the activation link is visited soon enough', function () {
       // Given
-      cy.stubServer('Authentication/RegisterConsumer/SuccessfulAccountConfirmation')
+      cy.stubServer({
+        'ActivateConsumer': 'Authentication/RegisterConsumer/SuccessfulAccountConfirmation'
+      })
 
       // When
       visitActivationLink()
@@ -177,7 +193,9 @@ describe('Consumer authentication', function(){
 
     it('displays an error message when something is wrong with the link', function () {
       // Given
-      cy.stubServer('Authentication/SignupExpiredLink')
+      cy.stubServer({
+        'ActivateConsumer': 'Authentication/SignupExpiredLink'
+      })
 
       // When
       visitActivationLink()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -2,24 +2,32 @@ import { responseStub } from './stubHelpers'
 
 const isGraphQL = (path, method) => path.includes('/graphql/') && method === 'POST'
 
-Cypress.Commands.add('stubGraphqlResponse', response => {
+Cypress.Commands.add('stubGraphqlServer', (operations = {}) => {
   cy.on('window:before:load', (win) => {
     const originalFunction = win.fetch
 
-    function fetch (path, { _, method }) {
-      if (isGraphQL(path, method)) {
-        return responseStub(response)
+    function serverStub (path, body) {
+      const { operationName } = JSON.parse(body)
+      if (Object.keys(operations).indexOf(operationName) !== false) {
+        const response = operations[operationName]
+        const stub = responseStub(response)
+        return Promise.resolve(stub)
       }
-      return originalFunction.apply(this, arguments)
+      return Promise.reject(new Error(`Not found: ${path}`))
     }
 
-    cy.stub(win, 'fetch', fetch).as('graphql')
+    function fetch (path, { method, body }) {
+      return isGraphQL(path, method) ? serverStub(path, body) : originalFunction.apply(this, arguments)
+    }
+
+    cy.stub(win, 'fetch').callsFake(fetch).as('graphql')
   })
 })
 
-Cypress.Commands.add('stubServer', fixture => {
-  cy.fixture(fixture)
-    .then(json => {
-      cy.stubGraphqlResponse(json)
-    })
+Cypress.Commands.add('stubServer', fixtures => {
+  for (const [key, value] of Object.entries(fixtures)) {
+    cy.fixture(value)
+      .then(json => { fixtures[key] = json })
+  }
+  cy.stubGraphqlServer(fixtures)
 })


### PR DESCRIPTION
[Recap of our workflow](https://softozor.github.io/github_workflow.html) 

# Prerequisites

- [x] You have configured the triggering of the pre-commit hook on your local repository's clone.
- [x] You have covered your code with unit and acceptance tests
- [x] The feature you have implemented has no tag `@wip` any more
- [x] None of the feature files have a tag `@current` or `@focus`

# Changes

The stubbed server can now issue the answer to several different queries.

# How to use the feature

Use the command `cy.stubServer`.